### PR TITLE
update to cli.py

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -171,7 +171,7 @@ class Cli(object):
 
         while True:
             if not self.queueLocation.empty():
-                    status = self.__process_event(self.queueLocation, None)
+                    status = self.__process_event(self.queueLocation)
                     if status == Event.LOC:
                         return True
                     elif status == Event.LOC_ERR:


### PR DESCRIPTION
Fix error for commandline RPI gps

Waiting for GPS fix:  9600-8N1
Traceback (most recent call last):
  File "rtlsdr_scan.py", line 135, in <module>
    Cli(args)
  File "/root/build/RTLSDR-Scanner/src/cli.py", line 150, in __init__
    if not self.__gps_wait():
  File "/root/build/RTLSDR-Scanner/src/cli.py", line 174, in __gps_wait
    status = self.__process_event(self.queueLocation, None)
TypeError: __process_event() takes exactly 2 arguments (3 given)