### PR TITLE
Modularized and added support for setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,42 @@
+import os
+from setuptools import setup
+
+def local_file(fname):
+    return os.path.relpath(os.path.join(os.path.dirname(__file__), fname))
+
+# Utility function to read the README file.
+# Used for the long_description.  It's nice, because now 1) we have a top level
+# README file and 2) it's easier to type in the README file than to put a raw
+# string in below ...
+def read(fname):
+    return open(local_file(fname)).read()
+
+with open(local_file("src/version.py")) as o:
+        exec(o.read())
+
+setup(
+    name = "rtlsdr_scanner",
+    version = __version__,
+    author = "Al Brown",
+    author_email = "al@eartoearoak.com",
+    description = ("A cross platform Python frequency scanning GUI for the "
+                   "OsmoSDR library."),
+    license = "GPLv3",
+    url = "http://eartoearoak.com/software/rtlsdr-scanner",
+    packages=["rtlsdr_scanner"],
+    package_dir={"rtlsdr_scanner": "src"},
+    scripts=["src/rtlsdr_scan.py"],
+    install_requires=["wxPython",
+                      "matplotlib",
+                      "numpy",
+                      "Pillow",
+                      "pyserial",
+                      "pyrtlsdr"
+    ],
+    long_description=read("readme.md"),
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Topic :: Utilities",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+    ],
+)

--- a/src/cli.py
+++ b/src/cli.py
@@ -32,14 +32,14 @@ import threading
 import time
 from urlparse import urlparse
 
-from constants import SAMPLE_RATE
-from devices import DeviceRTL, get_devices_rtl
-from events import Event
-from file import save_plot, export_plot, ScanInfo, File
-from location import ThreadLocation
-from misc import nearest, calc_real_dwell, next_2_to_pow, get_dwells
-from scan import ThreadScan, update_spectrum, ThreadProcess
-from settings import Settings
+from .constants import SAMPLE_RATE
+from .devices import DeviceRTL, get_devices_rtl
+from .events import Event
+from .file import save_plot, export_plot, ScanInfo, File
+from .location import ThreadLocation
+from .misc import nearest, calc_real_dwell, next_2_to_pow, get_dwells
+from .scan import ThreadScan, update_spectrum, ThreadProcess
+from .settings import Settings
 
 
 class Cli(object):

--- a/src/dialogs_devices.py
+++ b/src/dialogs_devices.py
@@ -30,13 +30,13 @@ from urlparse import urlparse
 from wx import grid
 import wx
 
-from constants import TUNER
-from widgets import TickCellRenderer, SatLevel
-from devices import DeviceRTL, DeviceGPS
-from dialogs_prefs import DialogOffset
-from events import Event
-from location import ThreadLocation
-from misc import nearest, limit, get_serial_ports
+from .constants import TUNER
+from .widgets import TickCellRenderer, SatLevel
+from .devices import DeviceRTL, DeviceGPS
+from .dialogs_prefs import DialogOffset
+from .events import Event
+from .location import ThreadLocation
+from .misc import nearest, limit, get_serial_ports
 
 
 class DialogDevicesRTL(wx.Dialog):

--- a/src/dialogs_file.py
+++ b/src/dialogs_file.py
@@ -39,16 +39,16 @@ import wx
 from wx.grid import GridCellDateTimeRenderer
 from wx.lib.masked.numctrl import NumCtrl, EVT_NUM
 
-from constants import SAMPLE_RATE, TUNER
-from events import Event
-from file import export_image, File
-from misc import format_time
-from panels import PanelColourBar
-from plot_line import Plotter
-from spectrum import Extent, count_points
-from utils_mpl import get_colours, create_heatmap
-from utils_wx import ValidatorCoord
-from widgets import TickCellRenderer
+from .constants import SAMPLE_RATE, TUNER
+from .events import Event
+from .file import export_image, File
+from .misc import format_time
+from .panels import PanelColourBar
+from .plot_line import Plotter
+from .spectrum import Extent, count_points
+from .utils_mpl import get_colours, create_heatmap
+from .utils_wx import ValidatorCoord
+from .widgets import TickCellRenderer
 
 
 class DialogProperties(wx.Dialog):

--- a/src/dialogs_help.py
+++ b/src/dialogs_help.py
@@ -33,8 +33,8 @@ import numpy
 import serial
 import wx
 
-from misc import get_version_timestamp
-from utils_wx import load_bitmap
+from .misc import get_version_timestamp
+from .utils_wx import load_bitmap
 
 
 class DialogSysInfo(wx.Dialog):

--- a/src/dialogs_prefs.py
+++ b/src/dialogs_prefs.py
@@ -33,10 +33,10 @@ import wx
 from wx.lib.agw.cubecolourdialog import CubeColourDialog
 from wx.lib.masked.numctrl import NumCtrl
 
-from constants import F_MIN, F_MAX, SAMPLE_RATE, BANDWIDTH, WINFUNC
-from panels import PanelColourBar
-from rtltcp import RtlTcp
-from utils_mpl import get_colours
+from .constants import F_MIN, F_MAX, SAMPLE_RATE, BANDWIDTH, WINFUNC
+from .panels import PanelColourBar
+from .rtltcp import RtlTcp
+from .utils_mpl import get_colours
 
 
 class DialogOffset(wx.Dialog):

--- a/src/dialogs_toolbars.py
+++ b/src/dialogs_toolbars.py
@@ -26,7 +26,7 @@
 import wx
 from wx.lib.masked.numctrl import NumCtrl
 
-from constants import WINFUNC
+from .constants import WINFUNC
 
 
 class DialogSmoothPrefs(wx.Dialog):

--- a/src/dialogs_tools.py
+++ b/src/dialogs_tools.py
@@ -33,15 +33,15 @@ from wx import grid
 import wx
 from wx.lib import masked
 
-from constants import F_MIN, F_MAX, Cal, WINFUNC, PlotFunc
-from events import Event
-from file import File, open_plot
-from misc import format_precision, format_time
-from panels import PanelGraphCompare, PanelLine
-from plot_line import Plotter
-from spectrum import Extent, smooth_spectrum
-from utils_wx import close_modeless
-from widgets import SatLevel
+from .constants import F_MIN, F_MAX, Cal, WINFUNC, PlotFunc
+from .events import Event
+from .file import File, open_plot
+from .misc import format_precision, format_time
+from .panels import PanelGraphCompare, PanelLine
+from .plot_line import Plotter
+from .spectrum import Extent, smooth_spectrum
+from .utils_wx import close_modeless
+from .widgets import SatLevel
 
 
 class DialogCompare(wx.Dialog):

--- a/src/file.py
+++ b/src/file.py
@@ -41,9 +41,9 @@ import matplotlib
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 import wx
 
-from constants import APP_NAME
-from misc import format_iso_time
-from spectrum import create_mesh, sort_spectrum
+from .constants import APP_NAME
+from .misc import format_iso_time
+from .spectrum import create_mesh, sort_spectrum
 
 
 class File(object):

--- a/src/location.py
+++ b/src/location.py
@@ -37,10 +37,10 @@ from urlparse import urlparse
 import serial
 from serial.serialutil import SerialException
 
-from constants import LOCATION_PORT, APP_NAME
-from devices import DeviceGPS
-from events import post_event, EventThread, Event, Log
-from misc import format_iso_time, haversine, format_time, limit_to_ascii, limit, \
+from .constants import LOCATION_PORT, APP_NAME
+from .devices import DeviceGPS
+from .events import post_event, EventThread, Event, Log
+from .misc import format_iso_time, haversine, format_time, limit_to_ascii, limit, \
     get_resdir
 
 

--- a/src/main_window.py
+++ b/src/main_window.py
@@ -37,34 +37,34 @@ import webbrowser
 import wx
 from wx.lib.masked.numctrl import NumCtrl
 
-from constants import F_MIN, F_MAX, MODE, NFFT, DISPLAY, Warn, \
+from .constants import F_MIN, F_MAX, MODE, NFFT, DISPLAY, Warn, \
     Cal, Mode, APP_NAME, LOCATION_PORT
-from devices import get_devices_rtl
-from dialogs_devices import DialogDevicesRTL, DialogDevicesGPS
-from dialogs_file import DialogImageSize, DialogExportSeq, DialogExportGeo, \
+from .devices import get_devices_rtl
+from .dialogs_devices import DialogDevicesRTL, DialogDevicesGPS
+from .dialogs_file import DialogImageSize, DialogExportSeq, DialogExportGeo, \
     DialogProperties, DialogSaveWarn, DialogRestore
-from dialogs_help import DialogSysInfo, DialogAbout
-from dialogs_prefs import DialogPrefs, DialogAdvPrefs, DialogFormatting
-from dialogs_scan import DialogScanDelay
-from dialogs_tools import DialogCompare, DialogAutoCal, DialogSats, DialogSmooth, \
+from .dialogs_help import DialogSysInfo, DialogAbout
+from .dialogs_prefs import DialogPrefs, DialogAdvPrefs, DialogFormatting
+from .dialogs_scan import DialogScanDelay
+from .dialogs_tools import DialogCompare, DialogAutoCal, DialogSats, DialogSmooth, \
     DialogLog
-from events import EVENT_THREAD, Event, EventThread, post_event, Log, EventTimer
-from file import save_plot, export_plot, open_plot, ScanInfo, export_image, \
+from .events import EVENT_THREAD, Event, EventThread, post_event, Log, EventTimer
+from .file import save_plot, export_plot, open_plot, ScanInfo, export_image, \
     export_map, extension_add, File, run_file, export_gpx, Backups
-from location import ThreadLocation, LocationServer
-from menus import MenuMain, PopMenuMain
-from misc import RemoteControl, calc_samples, get_dwells, calc_real_dwell, \
+from .location import ThreadLocation, LocationServer
+from .menus import MenuMain, PopMenuMain
+from .misc import RemoteControl, calc_samples, get_dwells, calc_real_dwell, \
     get_version_timestamp, get_version_timestamp_repo, format_iso_time, limit
-from panels import PanelGraph
-from printer import PrintOut
-from scan import ThreadScan, update_spectrum, ThreadProcess
-from settings import Settings
-from spectrum import count_points, Extent
-from toolbars import Statusbar, NavigationToolbar
-from utils_google import create_gearth
-from utils_mpl import add_colours
-from utils_wx import load_icon
-from widgets import MultiButton
+from .panels import PanelGraph
+from .printer import PrintOut
+from .scan import ThreadScan, update_spectrum, ThreadProcess
+from .settings import Settings
+from .spectrum import count_points, Extent
+from .toolbars import Statusbar, NavigationToolbar
+from .utils_google import create_gearth
+from .utils_mpl import add_colours
+from .utils_wx import load_icon
+from .widgets import MultiButton
 
 from wx.lib.agw import aui
 

--- a/src/menus.py
+++ b/src/menus.py
@@ -24,7 +24,7 @@
 #
 import wx
 
-from constants import Mode
+from .constants import Mode
 
 
 class MenuMain(object):

--- a/src/misc.py
+++ b/src/misc.py
@@ -36,7 +36,7 @@ import urllib
 
 import serial.tools.list_ports
 
-from constants import SAMPLE_RATE, TIMESTAMP_FILE
+from .constants import SAMPLE_RATE, TIMESTAMP_FILE
 
 
 class RemoteControl(object):

--- a/src/panels.py
+++ b/src/panels.py
@@ -40,20 +40,20 @@ from matplotlib.lines import Line2D
 from matplotlib.ticker import AutoMinorLocator, ScalarFormatter
 import wx
 
-from constants import Display
-from misc import format_precision
-from plot_3d import Plotter3d
-from plot_controls import MouseZoom, MouseSelect
-from plot_line import Plotter
-from plot_preview import PlotterPreview
-from plot_spect import Spectrogram
-from plot_status import PlotterStatus
-from plot_time import PlotterTime
-from spectrum import split_spectrum_sort, Measure, reduce_points
-from toolbars import NavigationToolbar, NavigationToolbarCompare
-from utils_mpl import find_artists
-from utils_wx import close_modeless
-from widgets import GridToolTips, CheckBoxCellRenderer
+from .constants import Display
+from .misc import format_precision
+from .plot_3d import Plotter3d
+from .plot_controls import MouseZoom, MouseSelect
+from .plot_line import Plotter
+from .plot_preview import PlotterPreview
+from .plot_spect import Spectrogram
+from .plot_status import PlotterStatus
+from .plot_time import PlotterTime
+from .spectrum import split_spectrum_sort, Measure, reduce_points
+from .toolbars import NavigationToolbar, NavigationToolbarCompare
+from .utils_mpl import find_artists
+from .utils_wx import close_modeless
+from .widgets import GridToolTips, CheckBoxCellRenderer
 import wx.grid as wxGrid
 
 

--- a/src/plot_3d.py
+++ b/src/plot_3d.py
@@ -35,12 +35,12 @@ from matplotlib.gridspec import GridSpec
 from matplotlib.ticker import ScalarFormatter, AutoMinorLocator
 from mpl_toolkits.mplot3d import Axes3D  # @UnresolvedImport @UnusedImport
 
-from constants import PlotFunc
-from events import post_event, EventThread, Event
-from misc import format_time, format_precision
-from spectrum import create_mesh, smooth_spectrum, Extent, diff_spectrum, \
+from .constants import PlotFunc
+from .events import post_event, EventThread, Event
+from .misc import format_time, format_precision
+from .spectrum import create_mesh, smooth_spectrum, Extent, diff_spectrum, \
     get_peaks
-from utils_mpl import utc_to_mpl
+from .utils_mpl import utc_to_mpl
 
 
 class Plotter3d(object):

--- a/src/plot_controls.py
+++ b/src/plot_controls.py
@@ -26,10 +26,10 @@
 import matplotlib
 from matplotlib.patches import Rectangle
 
-from plot_3d import Plotter3d
-from plot_preview import PlotterPreview
-from plot_status import PlotterStatus
-from plot_time import PlotterTime
+from .plot_3d import Plotter3d
+from .plot_preview import PlotterPreview
+from .plot_status import PlotterStatus
+from .plot_time import PlotterTime
 
 
 class MouseZoom():

--- a/src/plot_line.py
+++ b/src/plot_line.py
@@ -38,12 +38,12 @@ from matplotlib.text import Text
 from matplotlib.ticker import ScalarFormatter, AutoMinorLocator
 import numpy
 
-from constants import Markers, PlotFunc
-from events import EventThread, Event, post_event
-from misc import format_precision
-from spectrum import Measure, Extent, smooth_spectrum, \
+from .constants import Markers, PlotFunc
+from .events import EventThread, Event, post_event
+from .misc import format_precision
+from .spectrum import Measure, Extent, smooth_spectrum, \
     diff_spectrum, delta_spectrum, get_peaks
-from utils_mpl import get_colours
+from .utils_mpl import get_colours
 
 
 class Plotter(object):

--- a/src/plot_preview.py
+++ b/src/plot_preview.py
@@ -27,7 +27,7 @@ import sys
 
 import wx
 
-from events import post_event, EventThread, Event
+from .events import post_event, EventThread, Event
 
 
 vvPresent = False

--- a/src/plot_spect.py
+++ b/src/plot_spect.py
@@ -37,12 +37,12 @@ from matplotlib.text import Text
 from matplotlib.ticker import ScalarFormatter, AutoMinorLocator
 import numpy
 
-from constants import Markers, PlotFunc
-from events import EventThread, Event, post_event
-from misc import format_time, format_precision
-from spectrum import split_spectrum, Measure, smooth_spectrum, Extent, \
+from .constants import Markers, PlotFunc
+from .events import EventThread, Event, post_event
+from .misc import format_time, format_precision
+from .spectrum import split_spectrum, Measure, smooth_spectrum, Extent, \
     diff_spectrum, get_peaks
-from utils_mpl import utc_to_mpl
+from .utils_mpl import utc_to_mpl
 
 
 class Spectrogram(object):

--- a/src/plot_status.py
+++ b/src/plot_status.py
@@ -27,9 +27,9 @@ import threading
 from matplotlib.font_manager import FontProperties
 from matplotlib.table import Table
 
-from events import post_event, EventThread, Event
-from misc import format_time, format_precision
-from utils_mpl import find_artists, set_table_colour
+from .events import post_event, EventThread, Event
+from .misc import format_time, format_precision
+from .utils_mpl import find_artists, set_table_colour
 
 
 class PlotterStatus(object):

--- a/src/plot_time.py
+++ b/src/plot_time.py
@@ -27,8 +27,8 @@ import time
 
 from matplotlib.ticker import ScalarFormatter, AutoMinorLocator
 
-from events import post_event, EventThread, Event
-from utils_mpl import utc_to_mpl, set_date_ticks
+from .events import post_event, EventThread, Event
+from .utils_mpl import utc_to_mpl, set_date_ticks
 
 
 class PlotterTime(object):

--- a/src/rtlsdr_scan.py
+++ b/src/rtlsdr_scan.py
@@ -45,11 +45,11 @@ import os.path
 import signal
 import sys
 
-from cli import Cli
-from constants import APP_NAME
-from file import File
-from main_window import FrameMain, RtlSdrScanner
-from misc import set_version_timestamp
+from rtlsdr_scanner.cli import Cli
+from rtlsdr_scanner.constants import APP_NAME
+from rtlsdr_scanner.file import File
+from rtlsdr_scanner.main_window import FrameMain, RtlSdrScanner
+from rtlsdr_scanner.misc import set_version_timestamp
 
 if not hasattr(sys, 'frozen'):
     try:

--- a/src/rtlsdr_scan_view.py
+++ b/src/rtlsdr_scan_view.py
@@ -29,9 +29,9 @@ from os.path import os
 import sys
 import wx
 
-from file import File, open_plot
-from settings import Settings
-from spectrum import sort_spectrum
+from .file import File, open_plot
+from .settings import Settings
+from .spectrum import sort_spectrum
 
 if not hasattr(sys, 'frozen'):
     import visvis as vv

--- a/src/rtltcp.py
+++ b/src/rtltcp.py
@@ -30,7 +30,7 @@ import threading
 
 import numpy
 
-from events import post_event, EventThread, Event
+from .events import post_event, EventThread, Event
 
 
 class RtlTcpCmd(object):

--- a/src/scan.py
+++ b/src/scan.py
@@ -31,8 +31,8 @@ import time
 import matplotlib
 import rtlsdr
 
-from constants import SAMPLE_RATE, BANDWIDTH, WINFUNC
-from events import EventThread, Event, post_event
+from .constants import SAMPLE_RATE, BANDWIDTH, WINFUNC
+from .events import EventThread, Event, post_event
 import rtltcp
 from collections import OrderedDict
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -27,8 +27,8 @@ import ConfigParser
 
 import wx
 
-from constants import Display, Mode, PlotFunc
-from devices import DeviceRTL, format_device_rtl_name, DeviceGPS
+from .constants import Display, Mode, PlotFunc
+from .devices import DeviceRTL, format_device_rtl_name, DeviceGPS
 
 
 class Settings(object):

--- a/src/spectrum.py
+++ b/src/spectrum.py
@@ -29,9 +29,9 @@ from operator import itemgetter, mul
 from matplotlib.dates import seconds
 import numpy
 
-from constants import WINFUNC
-from misc import db_to_level, level_to_db
-from utils_mpl import utc_to_mpl
+from .constants import WINFUNC
+from .misc import db_to_level, level_to_db
+from .utils_mpl import utc_to_mpl
 
 
 class Extent(object):

--- a/src/toolbars.py
+++ b/src/toolbars.py
@@ -33,13 +33,13 @@ from matplotlib.backends.backend_wxagg import NavigationToolbar2WxAgg
 import wx
 from wx.animate import AnimationCtrl, Animation
 
-from constants import Display, PlotFunc
-from dialogs_toolbars import DialogSmoothPrefs, DialogPeakThreshold
-from events import Log
-from misc import get_resource_path
-from utils_mpl import get_colours
-from utils_wx import load_bitmap
-from widgets import Led
+from .constants import Display, PlotFunc
+from .dialogs_toolbars import DialogSmoothPrefs, DialogPeakThreshold
+from .events import Log
+from .misc import get_resource_path
+from .utils_mpl import get_colours
+from .utils_wx import load_bitmap
+from .widgets import Led
 
 
 class Statusbar(wx.StatusBar):

--- a/src/utils_google.py
+++ b/src/utils_google.py
@@ -22,7 +22,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
-from constants import APP_NAME, LOCATION_PORT
+from .constants import APP_NAME, LOCATION_PORT
 
 
 def create_gearth(handle):

--- a/src/utils_wx.py
+++ b/src/utils_wx.py
@@ -27,7 +27,7 @@ import os
 
 import wx
 
-from misc import get_resdir, get_script_dir
+from .misc import get_resdir, get_script_dir
 
 
 class ValidatorCoord(wx.PyValidator):

--- a/src/version.py
+++ b/src/version.py
@@ -1,0 +1,9 @@
+"""
+    rtlsdr_scanner.version
+    ======================
+
+    Version information.
+"""
+
+__version_info__ = (1, 0, 22494, 51273)
+__version__ = ".".join(str(x) for x in __version_info__)


### PR DESCRIPTION
This is my attempt to modularize the code and add support for setuptools. This ease downstream distro packaging. I tried to sanely set 'setup.py' metadata, but it may still need  some improvements. I also changed all local imports to relative path, because recently there was opened downstream Fedora bug: https://bugzilla.redhat.com/show_bug.cgi?id=1383513 regarding conflicting name with the Event package. While I have been trying to fix this bug, I have decided to also fix the modularization.
