### PR TITLE
Updated URL launched by update checker from sf.net to GitHub. Fixes #41

### DIFF
--- a/nsis/rtlsdr_scanner.nsi
+++ b/nsis/rtlsdr_scanner.nsi
@@ -345,7 +345,7 @@ Function update_check
 			${NSD_SetText} $UpdateText ${UPDATE_FOUND}
 			MessageBox MB_YESNO|MB_ICONQUESTION "Installer update found, download now (recommended)?" IDYES download IDNO skip
 			download:
-				ExecShell "open" "http://sourceforge.net/projects/rtlsdrscanner/files/latest/download"
+				ExecShell "open" "https://github.com/EarToEarOak/RTLSDR-Scanner/releases/latest"
 				SendMessage $HWNDPARENT ${WM_CLOSE} 0 0
 				Quit
 			skip:


### PR DESCRIPTION
Note: this only loads the page; it won't automatically download the installer .exe.  We could update it to include the filename in the URL, but that may break unexpectedly in the fuiture if anyone changes the filename of the installer.  (There may be a way to address that within NSIS itself, though; is the generated EXE filename a variable somewhere?)